### PR TITLE
Add documentation for API endpoints

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -1,0 +1,13 @@
+# API Documentation
+
+This document provides information about all available endpoints in the Nest.js REST API.
+
+> **Note**: All requests must include the `x-api-key` header with any value to pass the authorization check. In these examples, the `x-api-key` header is omitted for brevity.
+
+## Endpoints
+
+Documentation for each endpoint is available in the following sections:
+
+- [Users](./docs/API_USERS.md)
+- [Projects](./docs/API_PROJECTS.md)
+- [Tasks](./docs/API_TASKS.md)

--- a/docs/API_PROJECTS.md
+++ b/docs/API_PROJECTS.md
@@ -1,0 +1,192 @@
+# Projects API Documentation
+
+This document provides information about all available endpoints for managing projects.
+
+[← Go to main docs](../API_DOCUMENTATION.md)
+
+- [Users API Documentation](API_USERS.md)
+- [Task API Documentation](API_TASKS.md)
+
+## Get project from ID
+
+Retrieves a project by its ID.
+
+- `GET` - `/projects/:id`
+- Param:
+  - `id` - The ID of the project | `UUID`
+- Returns: `Project` object.
+
+### Example
+
+```
+GET "http://localhost:3000/projects/36d909dd-3bbc-4f51-9213-b0c05077e9d4"
+
+Response:
+{
+  "id": 36d909dd-3bbc-4f51-9213-b0c05077e9d4,
+  "name": "Project 1",
+  "description": "This is project 1",
+  "createdAt": "2021-01-01T00:00:00.000Z",
+  "updatedAt": "2021-01-01T00:00:00.000Z"
+}
+```
+
+## Create project
+
+Creates a new project.
+
+- `POST` - `/projects`
+- Body:
+  - `name` - The name of the project | `string`
+  - `description` - The description of the project | `string`
+- Returns: `Project` object.
+
+### Example
+
+```
+POST "http://localhost:3000/projects"
+
+Body:
+{
+  "name": "Project 2",
+  "description": "This is project 2"
+}
+
+Response:
+{
+  "id": 36d909dd-3bbc-4f51-9213-b0c05077e9d4,
+  "name": "Project 1",
+  "description": "This is project 1",
+  "createdAt": "2021-01-01T00:00:00.000Z",
+  "updatedAt": "2021-01-01T00:00:00.000Z"
+}
+```
+
+## Update project
+
+Updates an existing project.
+
+- `PATCH` - `/projects/:id`
+- Param:
+  - `id` - The ID of the project | `UUID`
+- Body:
+  - `name` - The name of the project | `string`
+  - `description` - The description of the project | `string`
+- Returns: `Project` object.
+
+### Example
+
+```
+PATCH "http://localhost:3000/projects/36d909dd-3bbc-4f51-9213-b0c05077e9d4"
+
+Body:
+{
+  "name": "Project 2 Updated",
+  "description": "This is project 2 updated"
+}
+
+Response:
+{
+  "id": 36d909dd-3bbc-4f51-9213-b0c05077e9d4,
+  "name": "Project 2 Updated",
+  "description": "This is project 2 updated",
+  "createdAt": "2021-01-01T00:00:00.000Z",
+  "updatedAt": "2021-01-01T00:00:00.000Z"
+}
+```
+
+## Add user to project
+
+Adds a user to a project.
+
+- `POST` - `/projects/add/`
+- Body:
+  - `projectId` - The ID of the project | `UUID`
+  - `userId` - The ID of the user | `UUID`
+- Returns: `Project` object.
+
+### Example
+
+```
+PATCH "http://localhost:3000/projects/add"
+
+Body:
+{
+  "projectId": "36d909dd-3bbc-4f51-9213-b0c05077e9d4",
+  "userId": "7b3b9b3b-3b3b-3b3b-3b3b-3b3b3b3b3b3b"
+}
+
+Response:
+{
+  "id": 36d909dd-3bbc-4f51-9213-b0c05077e9d4,
+  "name": "Project 1",
+  "description": "This is project 1",
+  "createdAt": "2021-01-01T00:00:00.000Z",
+  "updatedAt": "2021-01-01T00:00:00.000Z",
+  "users": [
+    {
+      "id": 7b3b9b3b-3b3b-3b3b-3b3b-3b3b3b3b3b3b,
+      "firstName": "John",
+      "lastName": "Doe",
+      "email": "
+      "location": "New York, NY"
+    }
+  ]
+}
+```
+
+## Remove user from project
+
+Removes a user from a project.
+
+- `PATCH` - `/projects/remove/`
+- Body:
+  - `projectId` - The ID of the project | `UUID`
+  - `userId` - The ID of the user | `UUID`
+- Returns: `Project` object.
+
+### Example
+
+```
+PATCH "http://localhost:3000/projects/remove"
+
+Body:
+{
+  "projectId": "36d909dd-3bbc-4f51-9213-b0c05077e9d4",
+  "userId": "7b3b9b3b-3b3b-3b3b-3b3b-3b3b3b3b3b3b"
+}
+
+Response:
+{
+  "id": 36d909dd-3bbc-4f51-9213-b0c05077e9d4,
+  "name": "Project 1",
+  "description": "This is project 1",
+  "createdAt": "2021-01-01T00:00:00.000Z",
+  "updatedAt": "2021-01-01T00:00:00.000Z",
+  "users": []
+}
+```
+
+## Delete project
+
+Deletes a project.
+
+- `DELETE` - `/projects/:id`
+- Param:
+  - `id` - The ID of the project | `UUID`
+- Returns: `Project` object.
+
+### Example
+
+```
+DELETE "http://localhost:3000/projects/36d909dd-3bbc-4f51-9213-b0c05077e9d4"
+
+Response:
+{
+  "id": 36d909dd-3bbc-4f51-9213-b0c05077e9d4,
+  "name": "Project 1",
+  "description": "This is project 1",
+  "createdAt": "2021-01-01T00:00:00.000Z",
+  "updatedAt": "2021-01-01T00:00:00.000Z"
+}
+```

--- a/docs/API_TASKS.md
+++ b/docs/API_TASKS.md
@@ -1,0 +1,218 @@
+# Tasks API Documentation
+
+This document provides information about all available endpoints for managing tasks.
+
+[← Go to main docs](../API_DOCUMENTATION.md)
+
+- [Users API Documentation](API_USERS.md)
+- [Project API Documentation](API_PROJECTS.md)
+
+## Get task by ID
+
+Retrieves a task by its ID.
+
+- `GET` - `/tasks/:id`
+- Param:
+  - `id` - The ID of the task | `UUID`
+- Returns: `Task` object.
+
+### Example
+
+```
+GET "http://localhost:3000/tasks/f445341c-2f63-4c99-9a75-b3ab5038514f"
+
+Response:
+{
+  "id": "f445341c-2f63-4c99-9a75-b3ab5038514f",
+  "title": "Task 1",
+  "description": "This is the first task",
+  "status": "TODO",
+  "userId": "f445341c-2f63-4c99-9a75-b3ab5038514f",
+  "projectId": "f445341c-2f63-4c99-9a75-b3ab5038514f"
+}
+```
+
+## Get tasks by User ID
+
+Retrieves all tasks for a user by their ID.
+
+- `GET` - `/tasks/user/:userId?status=:status&page=:page&pageSize=:pageSize`
+- Param:
+  - `userId` - The ID of the user | `UUID`
+- Query params:
+  - `status` - The status of the tasks | `string`
+  - `page` - The page number | `number - default 1`
+  - `pageSize` - The number of tasks per page | `number default 10`
+- Returns: Array of `Task` objects together with the project ID and project name.
+
+### Example
+
+```
+GET "http://localhost:3000/tasks/user/f445341c-2f63-4c99-9a75-b3ab5038514f?status=TODO&page=1&pageSize=3"
+
+Response:
+[
+  {
+    "id": "f445341c-2f63-4c99-9a75-b3ab5038514f",
+    "title": "Task 1",
+    "description": "This is the first task",
+    "status": "TODO",
+    "project": {
+        "id": "36d909dd-3bbc-4f51-9213-b0c05077e9c2",
+        "name": "Project #2"
+    }
+  },
+  {
+    "id": "f445341c-2f63-4c99-9a75-b3ab5038514f",
+    "title": "Task 2",
+    "description": "This is the second task",
+    "status": "TODO",
+    "project": {
+        "id": "36d909dd-3bbc-4f51-9213-b0c05077e9c2",
+        "name": "Project #2"
+    }
+  },
+  {
+    "id": "f445341c-2f63-4c99-9a75-b3ab5038514f",
+    "title": "Task 3",
+    "description": "This is the third task",
+    "status": "TODO",
+    "project": {
+        "id": "36d909dd-3bbc-4f51-9213-b0c05077e9c2",
+        "name": "Project #2"
+    }
+  }
+]
+```
+
+## Create Task
+
+Creates a new task.
+
+- `POST` - `/tasks`
+- Body:
+  - `title` - The title of the task | `string`
+  - `description` - The description of the task | `string`
+  - `status` - The status of the task | `string - "TODO", "DOING", "IN REVIEW", "DONE", "DROPPED"`
+  - `userId` - The ID of the user assigned to the task | `UUID`
+  - `projectId` - The ID of the project the task belongs to | `UUID`
+- Returns: `Task` object along side the associated `User` and `Project` objects.
+
+### Example
+
+```
+POST "http://localhost:3000/tasks"
+
+Body:
+{
+  "title": "Task 1",
+  "description": "This is the first task",
+  "status": "TODO",
+  "userId": "f445341c-2f63-4c99-9a75-b3ab5038514f",
+  "projectId": "f445341c-2f63-4c99-9a75-b3ab5038514f"
+}
+
+Response:
+{
+  "id": "f445341c-2f63-4c99-9a75-b3ab5038514f",
+  "title": "Task 1",
+  "description": "This is the first task",
+  "status": "TODO",
+  "user": {
+    "id": "f445341c-2f63-4c99-9a75-b3ab5038514f",
+    "firstName": "John",
+    "lastName": "Doe",
+    "email": "example@email.com",
+    "location": "New York, NY"
+  },
+  "project": {
+    "id": "f445341c-2f63-4c99-9a75-b3ab5038514f",
+    "name": "Project #1"
+    "description": "This is the first project",
+    "createdAt": "2021-08-01T00:00:00.000Z",
+    "updatedAt": "2021-08-01T00:00:00.000Z"
+  }
+}
+```
+
+## Update Task
+
+Updates an existing task.
+
+- `PATCH` - `/tasks/:id`
+- Param:
+  - `id` - The ID of the task | `UUID`
+- Body:
+  - `title` - The title of the task | `string`
+  - `description` - The description of the task | `string`
+  - `status` - The status of the task | `string - "TODO", "DOING", "IN REVIEW", "DONE", "DROPPED"`
+  - `userId` - The ID of the user assigned to the task | `UUID`
+  - `projectId` - The ID of the project the task belongs to | `UUID`
+- Returns: `Task` object along side the associated `User` object.
+
+### Example
+
+```
+PATCH "http://localhost:3000/tasks/f445341c-2f63-4c99-9a75-b3ab5038514f"
+
+Body:
+{
+  "status": "DONE",
+}
+
+Response:
+{
+  "id": "f445341c-2f63-4c99-9a75-b3ab5038514f",
+  "title": "Task 1",
+  "description": "This is the first task",
+  "status": "DONE",
+  "user": {
+    "id": "f445341c-2f63-4c99-9a75-b3ab5038514f",
+    "firstName": "John",
+    "lastName": "Doe",
+    "email": "example@email.com",
+    "location": "New York, NY"
+  }
+}
+```
+
+## Count Tasks
+
+Counts the number of tasks for a user.
+
+- `GET` - `/tasks/count/:userId?status=:status`
+- Param:
+  - `userId` - The ID of the user | `UUID`
+- Query params:
+  - `status` - The status of the tasks | `string - "TODO", "DOING", "IN REVIEW", "DONE", "DROPPED"`
+
+### Example
+
+```
+GET "http://localhost:3000/tasks/count/f445341c-2f63-4c99-9a75-b3ab5038514f?status=TODO"
+
+Response: 5
+```
+
+## Delete Task
+
+Deletes a task by its ID.
+
+- `DELETE` - `/tasks/:id`
+- Param:
+  - `id` - The ID of the task | `UUID`
+- Returns: `Task` object.
+
+### Example
+
+```
+DELETE "http://localhost:3000/tasks/f445341c-2f63-4c99-9a75-b3ab5038514f"
+
+Response:
+{
+  "id": "f445341c-2f63-4c99-9a75-b3ab5038514f",
+  "title": "Task 1",
+  "description": "This is the first task",
+  "status": "TODO"
+}
+```

--- a/docs/API_USERS.md
+++ b/docs/API_USERS.md
@@ -1,0 +1,150 @@
+# Users API Documentation
+
+This document provides information about all available endpoints for managing users.
+
+[← Go to main docs](../API_DOCUMENTATION.md)
+
+- [Project API Documentation](API_PROJECTS.md)
+- [Task API Documentation](API_TASKS.md)
+
+## Get User by ID
+
+Retrieves a user by their ID.
+
+- `GET` - `/users/:id`
+- Param:
+  - `id` - The ID of the user
+- Returns: `User` object.
+
+### Example
+
+```
+GET "http://localhost:3000/users/f445341c-2f63-4c99-9a75-b3ab5038514f"
+
+Response:
+{
+  "id": "f445341c-2f63-4c99-9a75-b3ab5038514f",
+  "firstName": "John",
+  "lastName": "Doe",
+  "email": "example@email.com",
+  "location": "New York, NY"
+}
+```
+
+## Get User by Email
+
+Retrieves a user by their email address.
+
+- `GET` - `/users/email/:email`
+- Param:
+  - `email` - The email address of the user
+- Returns: `User` object.
+
+### Example
+
+```
+GET "http://localhost:3000/users/example@gmail.com"
+
+Response:
+{
+  "id": "f445341c-2f63-4c99-9a75-b3ab5038514f",
+  "firstName": "John",
+  "lastName": "Doe",
+  "email": "example@email.com",
+  "location": "New York, NY"
+}
+```
+
+## Create User
+
+Creates a new user.
+
+- `POST` - `/users`
+- Body:
+  - `firstName` - The first name of the user
+  - `lastName` - The last name of the user
+  - `email` - The email address of the user
+  - `location` - The location of the user
+- Returns: `User` object.
+
+### Example
+
+```
+POST "http://localhost:3000/users"
+
+Body:
+{
+  "firstName": "John",
+  "lastName": "Doe",
+  "email": "example@email.com",
+  "location": "New York, NY"
+}
+
+Response:
+{
+  "id": "f445341c-2f63-4c99-9a75-b3ab5038514f",
+  "firstName": "John",
+  "lastName": "Doe",
+  "email": "example@email.com",
+  "location": "New York, NY"
+}
+```
+
+## Update User
+
+Updates an existing user.
+
+- `PATCH` - `/users/:id`
+- Parameters:
+  - `id` - The ID of the user
+- Body:
+  - `firstName` - The first name of the user
+  - `lastName` - The last name of the user
+  - `email` - The email address of the user
+  - `location` - The location of the user
+- Returns: `User` object.
+
+### Example
+
+```
+PATCH "http://localhost:3000/users/f445341c-2f63-4c99-9a75-b3ab5038514f"
+
+Body:
+{
+  "lastName": "Smith",
+  "location": "Los Angeles, CA"
+}
+
+Response:
+{
+  "id": "f445341c-2f63-4c99-9a75-b3ab5038514f",
+  "firstName": "Jane",
+  "lastName": "Smith",
+  "email": "example@email.com",
+  "location": "Los Angeles, CA"
+}
+```
+
+## Delete User
+
+Deletes a user.
+
+- `DELETE` - `/users/:id`
+- Parameters:
+  - `id` - The ID of the user
+- Returns: `User` object.
+
+### Example
+
+```
+DELETE "http://localhost:3000/users/f445341c-2f63-4c99-9a75-b3ab5038514f"
+
+Response:
+{
+  "id": "f445341c-2f63-4c99-9a75-b3ab5038514f",
+  "firstName": "John",
+  "lastName": "Doe",
+  "email": "example@email.com",
+  "location": "New York, NY"
+}
+```


### PR DESCRIPTION
This PR adds documentation for the following endpoints:
 - `/users`
 - `/projects`
 - `/tasks`